### PR TITLE
Moving nuspec to root solution folder

### DIFF
--- a/ChameleonForms.nuspec
+++ b/ChameleonForms.nuspec
@@ -36,14 +36,14 @@
     </dependencies>
   </metadata>
   <files>
-     <file src="bin\Release\ChameleonForms.dll" target="lib\NET40" />
-     <file src="bin\Release\ChameleonForms.pdb" target="lib\NET40" />
-     <file src="bin\Release\ChameleonForms.XML" target="lib\NET40" />
-     <file src="..\AppStart.cs.pp" target="content\App_Start\RegisterChameleonFormsComponents.cs.pp" />
-     <file src="..\web.config.transform" target="content\Views" />
-     <file src="..\ChameleonForms.Example\Scripts\jquery.validate.unobtrusive.chameleon.js" target="content\Scripts\jquery.validate.unobtrusive.chameleon.js" />
-     <file src="..\ChameleonForms.Example\Scripts\jquery.validate.unobtrusive.twitterbootstrap.js" target="content\Scripts\jquery.validate.unobtrusive.twitterbootstrap.js" />
-     <file src="..\ChameleonForms.Example\Content\chameleonforms-twitterbootstrap.css" target="content\Content\chameleonforms-twitterbootstrap.css" />
-     <file src="readme.txt" target="" />
+     <file src="ChameleonForms\bin\Release\ChameleonForms.dll" target="lib\NET40" />
+     <file src="ChameleonForms\bin\Release\ChameleonForms.pdb" target="lib\NET40" />
+     <file src="ChameleonForms\bin\Release\ChameleonForms.XML" target="lib\NET40" />
+     <file src="AppStart.cs.pp" target="content\App_Start\RegisterChameleonFormsComponents.cs.pp" />
+     <file src="web.config.transform" target="content\Views" />
+     <file src="ChameleonForms.Example\Scripts\jquery.validate.unobtrusive.chameleon.js" target="content\Scripts\jquery.validate.unobtrusive.chameleon.js" />
+     <file src="ChameleonForms.Example\Scripts\jquery.validate.unobtrusive.twitterbootstrap.js" target="content\Scripts\jquery.validate.unobtrusive.twitterbootstrap.js" />
+     <file src="ChameleonForms.Example\Content\chameleonforms-twitterbootstrap.css" target="content\Content\chameleonforms-twitterbootstrap.css" />
+     <file src="ChameleonForms\readme.txt" target="" />
   </files>
 </package>

--- a/ChameleonForms.sln
+++ b/ChameleonForms.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		AppStart.cs.pp = AppStart.cs.pp
 		BREAKING_CHANGES.md = BREAKING_CHANGES.md
+		ChameleonForms.nuspec = ChameleonForms.nuspec
 		LICENSE = LICENSE
 		logo.png = logo.png
 		README.md = README.md

--- a/ChameleonForms/ChameleonForms.csproj
+++ b/ChameleonForms/ChameleonForms.csproj
@@ -149,7 +149,6 @@
     <Compile Include="Templates\TwitterBootstrap3\ButtonHtmlAttributesExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="ChameleonForms.nuspec" />
     <None Include="packages.config" />
     <Content Include="Templates\Default\DefaultHtmlHelpers.cshtml">
       <Generator>RazorGenerator</Generator>


### PR DESCRIPTION
- Fixes default exclusion of our css/js <file attributes that start with a dot - using NoDefaultExcludes is an option but the nuspec seems to make more sense in the root folder anyway.
