### PR TITLE
Overloads for HumanizedLabels.Register to support all Humanizer letter casings

### DIFF
--- a/ChameleonForms.Tests/App.config
+++ b/ChameleonForms.Tests/App.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.15.0" newVersion="2.2.15.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.18.0" newVersion="2.2.18.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/ChameleonForms.Tests/ChameleonForms.Tests.csproj
+++ b/ChameleonForms.Tests/ChameleonForms.Tests.csproj
@@ -52,6 +52,10 @@
     <Reference Include="FizzWare.NBuilder">
       <HintPath>..\packages\NBuilder.3.0.1.1\lib\FizzWare.NBuilder.dll</HintPath>
     </Reference>
+    <Reference Include="Humanizer, Version=1.0.0.0, Culture=neutral, PublicKeyToken=979442b78dfc278e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Humanizer.1.0\lib\NET40\Humanizer.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>

--- a/ChameleonForms.Tests/HumanizedLabelsTests.cs
+++ b/ChameleonForms.Tests/HumanizedLabelsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Web.Mvc;
+using Humanizer;
 using NUnit.Framework;
 
 namespace ChameleonForms.Tests
@@ -15,6 +16,20 @@ namespace ChameleonForms.Tests
             var m = ModelMetadataProviders.Current.GetMetadataForProperty(null, typeof(NonHumanizedViewModel), "SomeFieldName");
 
             Assert.That(m.DisplayName, Is.EqualTo("Some field name"));
+        }
+
+        [Test]
+        [TestCase(LetterCasing.AllCaps, "SOME FIELD NAME")]
+        [TestCase(LetterCasing.LowerCase, "some field name")]
+        [TestCase(LetterCasing.Sentence, "Some field name")]
+        [TestCase(LetterCasing.Title, "Some Field Name")]
+        public void Humanize_model_labels_with_custom_casing(LetterCasing casing, string expected)
+        {
+            HumanizedLabels.Register(casing);
+
+            var m = ModelMetadataProviders.Current.GetMetadataForProperty(null, typeof(NonHumanizedViewModel), "SomeFieldName");
+
+            Assert.That(m.DisplayName, Is.EqualTo(expected));
         }
 
         [Test]

--- a/ChameleonForms.Tests/packages.config
+++ b/ChameleonForms.Tests/packages.config
@@ -4,6 +4,7 @@
   <package id="ApprovalUtilities" version="3.0.01" targetFramework="net40" />
   <package id="Autofac" version="3.1.1" targetFramework="net40" />
   <package id="AutofacContrib.NSubstitute" version="3.1.3" targetFramework="net40" />
+  <package id="Humanizer" version="1.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net40" />

--- a/ChameleonForms/HumanizedLabels.cs
+++ b/ChameleonForms/HumanizedLabels.cs
@@ -12,12 +12,14 @@ namespace ChameleonForms
     /// </summary>
     public class HumanizedLabels : DataAnnotationsModelMetadataProvider
     {
+        internal LetterCasing Casing { get; set; }
+
         /// <summary>
         /// Register the HumanizedLabels metadata provider as the current Model Metadata Provider.
         /// </summary>
-        public static void Register()
+        public static void Register(LetterCasing casing = LetterCasing.Sentence)
         {
-            ModelMetadataProviders.Current = new HumanizedLabels();
+            ModelMetadataProviders.Current = new HumanizedLabels() { Casing = casing };
         }
 
         protected override ModelMetadata CreateMetadata(IEnumerable<Attribute> attributes, Type containerType,
@@ -29,7 +31,7 @@ namespace ChameleonForms
             // Auto-sentence case for display name
             if (metadata.DisplayName == null && metadata.PropertyName != null)
             {
-                metadata.DisplayName = metadata.PropertyName.Humanize(LetterCasing.Sentence);
+                metadata.DisplayName = metadata.PropertyName.Humanize(Casing);
             }
 
             return metadata;


### PR DESCRIPTION
I saw in the doco that you could use some of the other Humanizer letter casing strategies by copying the HumanizeLabels class into your project and changing the selected enum. I thought it would be nicer to pass the LetterCasing enum value you want to the Register method. I used a default argument value of LetterCasing.Sentence so that the existing API and behaviour are not changed.
