### PR TITLE
Fixing a NullReferenceException, probably only occuring in MVC5

### DIFF
--- a/ChameleonForms/Component/Config/FieldConfiguration.cs
+++ b/ChameleonForms/Component/Config/FieldConfiguration.cs
@@ -657,7 +657,9 @@ namespace ChameleonForms.Component.Config
         /// <inheritdoc />
         public string ToHtmlString()
         {
-            return _field().ToHtmlString();
+            var field = _field();
+
+            return field != null ? field.ToHtmlString() : String.Empty;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
The `FieldConfiguration` returned from a `ValidationMessageFor` would throw on it's `ToHtmlString` call made by Razor.

The reason is that the `_field` member evaluates down to a call to `HtmlHelper.ValidationMessageFor` from `System.Web.Mvc` and, at least in MVC5, that returns `null` when there is no message to be had - which is most of the time.

I didn't research in what exactly the difference to the test project is that it makes the bug surface for me, but the MVC version difference is the one obvious suspect.

The suggested little addition of robustness fixes things for me.