### PR TITLE
Fixes for tests in the German culture.

### DIFF
--- a/ChameleonForms.AcceptanceTests/ModelBinding/Pages/ModelFieldType.cs
+++ b/ChameleonForms.AcceptanceTests/ModelBinding/Pages/ModelFieldType.cs
@@ -26,7 +26,9 @@ namespace ChameleonForms.AcceptanceTests.ModelBinding.Pages
         public ModelFieldType(Type fieldType, string format)
         {
             _fieldType = fieldType;
-            Format = format.Replace("{0:", "").Replace("}", "");
+
+            if (format != null && format != "{0}")
+                Format = format.Replace("{0:", "").Replace("}", "");
         }
 
         public object GetValueFromString(string stringValue)
@@ -68,7 +70,7 @@ namespace ChameleonForms.AcceptanceTests.ModelBinding.Pages
             var underlyingType = UnderlyingType;
 
             if (underlyingType == typeof (DateTime) && !string.IsNullOrEmpty(Format))
-                return DateTime.ParseExact(value, Format, new DateTimeFormatInfo(), DateTimeStyles.None);
+                return DateTime.ParseExact(value, Format, null, DateTimeStyles.None);
 
             return underlyingType.IsEnum
                 ? Enum.Parse(underlyingType, value)

--- a/ChameleonForms.Example/Controllers/ExampleFormsController.cs
+++ b/ChameleonForms.Example/Controllers/ExampleFormsController.cs
@@ -106,7 +106,7 @@ namespace ChameleonForms.Example.Controllers
         public int RequiredInt { get; set; }
         public int? OptionalInt { get; set; }
 
-        [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy hh:mm:sstt}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy HH:mm:ss}", ApplyFormatInEditMode = true)]
         public DateTime DateTime { get; set; }
         [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy}", ApplyFormatInEditMode = true)]
         public DateTime? NullableDateTime { get; set; }

--- a/ChameleonForms.Tests/FieldGenerator/DefaultFieldGeneratorTests.cs
+++ b/ChameleonForms.Tests/FieldGenerator/DefaultFieldGeneratorTests.cs
@@ -160,6 +160,8 @@ namespace ChameleonForms.Tests.FieldGenerator
             var autoSubstitute = AutoSubstituteContainer.Create();
             H = autoSubstitute.Resolve<HtmlHelper<TestFieldViewModel>>();
             ExampleFieldConfiguration = new FieldConfiguration().Attr("data-attr", "value");
+
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
         }
 
         protected DefaultFieldGenerator<TestFieldViewModel, T> Arrange<T>(Expression<Func<TestFieldViewModel,T>> property, params Action<TestFieldViewModel>[] vmSetter)

--- a/ChameleonForms.Tests/ModelBinders/DateTimeModelBinderShould.cs
+++ b/ChameleonForms.Tests/ModelBinders/DateTimeModelBinderShould.cs
@@ -24,6 +24,8 @@ namespace ChameleonForms.Tests.ModelBinders
             var c = AutoSubstituteContainer.Create();
             _context = c.Resolve<ControllerContext>();
             _formCollection = new FormCollection();
+
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
         }
 
         private ModelBindingContext ArrangeBindingContext()


### PR DESCRIPTION
I already mentioned that the tests don't run properly because of culture issues.

I fixed some of them in this pull requests.

The most important one is that I specify the invariant culture for all all `ChameleonForms.Tests` tests. That fixes all the broken tests of that kind for me.

I also fixed some issues I have with the acceptance tests, but not all.

One problem is that it's not easy to find a `DateTime` format string that survives a serialization-parsing-roundtrip in all cultures. The "tt" specifier doesn't exist in the German culture (and neither does it in the invariant culture), so I changed the example format to a 24h clock format.

There is a remaining issue unobtrusive javascript validation and cultures (which I don't use in my own apps). The javascript on the example forms don't validate because it can't parse decimals (as the dot is a comma in German numbers). Maybe I find a fix for this later, but right now unobtrusive validation isn't a priority for me.