### PR TITLE
Add HtmlAttributes.ToString that renders the html

### DIFF
--- a/ChameleonForms/HtmlAttributes.cs
+++ b/ChameleonForms/HtmlAttributes.cs
@@ -194,6 +194,12 @@ namespace ChameleonForms
             return sb.ToString();
         }
 
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return ToHtmlString();
+        }
+
         /// <summary>
         /// Returns the HTML attributes as a dictionary.
         /// </summary>


### PR DESCRIPTION
Otherwise you end up with weird stuff like: `form.Write(navigation.Submit("text")` rendering `ChameleonForms.Component.ButtonHtmlAttributes`