### PR TITLE
FieldConfiguration: Add extension methods that take Func<object, IHtmlString>

### DIFF
--- a/ChameleonForms/Component/Config/FieldConfigurationExtensions.cs
+++ b/ChameleonForms/Component/Config/FieldConfigurationExtensions.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Web;
+
 namespace ChameleonForms.Component.Config
 {
     /// <summary>
@@ -27,6 +30,85 @@ namespace ChameleonForms.Component.Config
         {
             if (config != null)
                 return config.Attr("autofocus", "autofocus");
+            return null;
+        }
+
+        /// <summary>
+        /// Override the HTML of the form field.
+        /// 
+        /// This gives you ultimate flexibility with your field HTML when it's
+        /// not quite what you want, but you still want the form template
+        /// (e.g. label, surrounding html and validation message).
+        /// </summary>
+        /// <param name="config">Field configuration to modify</param>
+        /// <param name="html">The HTML for the field</param>
+        /// <returns>The instance of <see cref="IFieldConfiguration"/> to allow for method chaining</returns>
+        public static IFieldConfiguration OverrideFieldHtml(this IFieldConfiguration config, Func<object, IHtmlString> html)
+        {
+            if (config != null)
+                return config.OverrideFieldHtml(html(null));
+            return null;
+        }
+
+        /// <summary>
+        /// Sets an inline label for a checkbox.
+        /// </summary>
+        /// <param name="labelHtml">The html to use for the label</param>
+        /// <param name="config">Field configuration to update</param>
+        /// <returns>The instance of <see cref="IFieldConfiguration"/> to allow for method chaining</returns>
+        public static IFieldConfiguration InlineLabel(this IFieldConfiguration config, Func<object, IHtmlString> labelHtml)
+        {
+            if (config != null)
+                return config.InlineLabel(labelHtml(null));
+            return null;
+        }
+        /// <summary>
+        /// Override the default label for the field.
+        /// </summary>
+        /// <param name="labelHtml">The text to use for the label</param>
+        /// <param name="config">Field configuration to update</param>
+        /// <returns>The instance of <see cref="IFieldConfiguration"/> to allow for method chaining</returns>
+        public static IFieldConfiguration Label(this IFieldConfiguration config, Func<object, IHtmlString> labelHtml)
+        {
+            if (config != null)
+                return config.Label(labelHtml(null));
+            return null;
+        }
+
+        /// <summary>
+        /// Supply a HTML hint to display along with the field.
+        /// </summary>
+        /// <param name="hint">The hint markup</param>
+        /// <param name="config">Field configuration to update</param>
+        /// <returns>The instance of <see cref="IFieldConfiguration"/> to allow for method chaining</returns>
+        public static IFieldConfiguration WithHint(this IFieldConfiguration config, Func<object, IHtmlString> hint)
+        {
+            if (config != null)
+                return config.WithHint(hint(null));
+            return null;
+        }
+        /// <summary>
+        /// Prepends the given HTML to the form field.
+        /// </summary>
+        /// <param name="html">The HTML to prepend</param>
+        /// <param name="config">Field configuration to update</param>
+        /// <returns>The instance of <see cref="IFieldConfiguration"/> to allow for method chaining</returns>
+        public static IFieldConfiguration Prepend(this IFieldConfiguration config, Func<object, IHtmlString> html)
+        {
+            if (config != null)
+                return config.Prepend(html(null));
+            return null;
+        }
+        /// <summary>
+        /// Appends the given HTML to the form field.
+        /// </summary>
+        /// <param name="html">The HTML to append</param>
+        /// <param name="config">Field configuration to update</param>
+        /// <returns>The instance of <see cref="IFieldConfiguration"/> to allow for method chaining</returns>
+        public static IFieldConfiguration Append(this IFieldConfiguration config, Func<object, IHtmlString> html)
+        {
+            if (config != null)
+                return config.Append(html(null));
             return null;
         }
     }


### PR DESCRIPTION
This allows using constructs like:

```
section.FieldFor(a => a.Property).WithHint(@<span>Inline html <u>here</u>!</span>)
```

Fixes: #136

BTW, I didn't see any test on razor so I could not add a test...
