### PR TITLE
PartialModelExpression: return LambdaExpression instead of object

### DIFF
--- a/ChameleonForms/Form.cs
+++ b/ChameleonForms/Form.cs
@@ -23,7 +23,7 @@ namespace ChameleonForms
         /// <param name="partialModelExpression">The expression that identifies the partial model</param>
         /// <param name="partialViewHelper">The HTML Helper from the partial view</param>
         /// <returns>The PartialViewForm wrapping the original form</returns>
-        IForm<TPartialModel> CreatePartialForm<TPartialModel>(object partialModelExpression, HtmlHelper<TPartialModel> partialViewHelper);
+        IForm<TPartialModel> CreatePartialForm<TPartialModel>(LambdaExpression partialModelExpression, HtmlHelper<TPartialModel> partialViewHelper);
     }
 
     /// <summary>
@@ -102,7 +102,7 @@ namespace ChameleonForms
         }
 
         /// <inheritdoc />
-        public IForm<TPartialModel> CreatePartialForm<TPartialModel>(object partialModelExpression, HtmlHelper<TPartialModel> partialViewHelper)
+        public IForm<TPartialModel> CreatePartialForm<TPartialModel>(LambdaExpression partialModelExpression, HtmlHelper<TPartialModel> partialViewHelper)
         {
             var partialModelAsExpression = partialModelExpression as Expression<Func<TModel, TPartialModel>>;
             if (partialModelAsExpression == null

--- a/ChameleonForms/PartialViewForm.cs
+++ b/ChameleonForms/PartialViewForm.cs
@@ -40,7 +40,7 @@ namespace ChameleonForms
             }
         }
 
-        public IForm<TChildPartialModel> CreatePartialForm<TChildPartialModel>(object childPartialModelExpression, HtmlHelper<TChildPartialModel> partialViewHelper)
+        public IForm<TChildPartialModel> CreatePartialForm<TChildPartialModel>(LambdaExpression childPartialModelExpression, HtmlHelper<TChildPartialModel> partialViewHelper)
         {
             var childPartialModelAsExpression = childPartialModelExpression as Expression<Func<TPartialModel, TChildPartialModel>>;
             var partialModelAsExpression = _partialModelProperty.Combine(childPartialModelAsExpression);

--- a/ChameleonForms/WebViewPageExtensions.cs
+++ b/ChameleonForms/WebViewPageExtensions.cs
@@ -21,7 +21,7 @@ namespace ChameleonForms
         /// <typeparam name="TPartialViewModel">View model type of the partial view</typeparam>
         /// <param name="partial">View page for partial view</param>
         /// <returns>current partial view model expression</returns>
-        public static object PartialModelExpression<TPartialViewModel>(this WebViewPage<TPartialViewModel> partial)
+        public static LambdaExpression PartialModelExpression<TPartialViewModel>(this WebViewPage<TPartialViewModel> partial)
         {
             object expression;
             if (!partial.ViewData.TryGetValue(PartialViewModelExpressionViewDataKey, out expression))
@@ -29,7 +29,7 @@ namespace ChameleonForms
                 throw new InvalidOperationException("Not currently inside a form partial view.");
             }
 
-            return expression;
+            return (LambdaExpression)expression;
         }
 
         /// <summary>


### PR DESCRIPTION
While we cannot know the exact type parameters, we can know that it should be a lambda expression

---

I'm not sure about .Net/IL ABI norms, but I think this will require recompilation of calling code, as IL includes the return type in the method signature.